### PR TITLE
Carthage support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,8 @@ after_success:
 before_install:
  - gem install -v 2.0.1 bundler
  - bundle _2.0.1_ install
+ - brew update
+ - brew outdated carthage || brew upgrade carthage
+before_deploy:
+  - carthage build --no-skip-current
+  - carthage archive RFIBANHelper

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ deploy:
   file: RFIBANHelper.framework.zip
   on:
     repo: TizianoCoroneo/IBAN-Helper
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10.1
+osx_image: xcode11.3
 cache:
 - bundler
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ deploy:
   api_key:
     secure: jwLd8O8UsQyAdk4fuLqN05/hIQe7+/8qBbK+8Q8+lASf0OS1jpxdT0vTqw0xMNV2Sq1lfdqKu+y1RRJG0UrUHvH4dAke0VIuDajnZY8cjlGf1lbDMmXieJMrSiEE7pCShqI4qsXOQAaGSL6ar5HS/buXj841WLDHT8I7Srs3FQj6X6iYFY+uA4y03A9I++8P+pfdhUKCg2KoZNmbamJ+icrAF/JsWji2wWEAOGvCzkdBsxOr8d5y6IobiOHXA/2/u7qVZQiS49jkU6nMPHnvpqszhjje6Jrky8b0WCGEID8PDYd1cmO6x2B+iPkeMIzVvt+t0GIlxDICQg6wS0dqe64OoYUULiulNsJeA/BXhYK5ILf9CXFf68eNw7mvEXjGvwJ91hfoq5acCA3c1QynBGcIVgVsIjKfGaLKA+TDs0Xh9FB6wOMS4iLjlfPaSvXk82vmRHa6zmPoXTHEQV2J7iandtqacJ1ZXfxdDeF9UMqd2YN0I413CKM4lOIQQijWupF0CkMopltzUrErtt5YT6HKcuhyUAiY1MsM6b3c9E8WKhOaz2X6YFodn3gapkRc5d0MstjUoJ+ENKOHGPsV7sjcPYepmqZsvPvT4xyjGQFi7ZZF5nlw4e09c52kfT8u7+nOyl0Hngs2uCnvZ+e17nUtBC3MTAfLLpyGIY4BwyA=
   file: RFIBANHelper.framework.zip
+  skip_cleanup: true
   on:
     repo: TizianoCoroneo/IBAN-Helper
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ script:
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 before_install:
-- gem install -v 2.0.1 bundler
-- bundle _2.0.1_ install
+- gem install bundler
 - brew update
 - brew outdated carthage || brew upgrade carthage
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ before_deploy:
 deploy:
   provider: releases
   api_key:
-    secure: jwLd8O8UsQyAdk4fuLqN05/hIQe7+/8qBbK+8Q8+lASf0OS1jpxdT0vTqw0xMNV2Sq1lfdqKu+y1RRJG0UrUHvH4dAke0VIuDajnZY8cjlGf1lbDMmXieJMrSiEE7pCShqI4qsXOQAaGSL6ar5HS/buXj841WLDHT8I7Srs3FQj6X6iYFY+uA4y03A9I++8P+pfdhUKCg2KoZNmbamJ+icrAF/JsWji2wWEAOGvCzkdBsxOr8d5y6IobiOHXA/2/u7qVZQiS49jkU6nMPHnvpqszhjje6Jrky8b0WCGEID8PDYd1cmO6x2B+iPkeMIzVvt+t0GIlxDICQg6wS0dqe64OoYUULiulNsJeA/BXhYK5ILf9CXFf68eNw7mvEXjGvwJ91hfoq5acCA3c1QynBGcIVgVsIjKfGaLKA+TDs0Xh9FB6wOMS4iLjlfPaSvXk82vmRHa6zmPoXTHEQV2J7iandtqacJ1ZXfxdDeF9UMqd2YN0I413CKM4lOIQQijWupF0CkMopltzUrErtt5YT6HKcuhyUAiY1MsM6b3c9E8WKhOaz2X6YFodn3gapkRc5d0MstjUoJ+ENKOHGPsV7sjcPYepmqZsvPvT4xyjGQFi7ZZF5nlw4e09c52kfT8u7+nOyl0Hngs2uCnvZ+e17nUtBC3MTAfLLpyGIY4BwyA=
+    secure: your-travis-release-token-here
   file: RFIBANHelper.framework.zip
   skip_cleanup: true
   on:
-    repo: TizianoCoroneo/IBAN-Helper
+    repo: readefries/IBAN-Helper
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
 - bundler
 script:
 - xcodebuild test -project Example/RFIBANHelper.xcodeproj -scheme RFIBANHelper build
-  test -destination platform='iOS Simulator,name=iPhone 7,OS=latest'
+  test -destination platform='iOS Simulator,name=iPhone 11,OS=latest'
 - bundle exec pod lib lint --quick
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,25 @@
 language: objective-c
 osx_image: xcode10.1
 cache:
- - bundler
+- bundler
 script:
- - xcodebuild test -project Example/RFIBANHelper.xcodeproj -scheme RFIBANHelper build test -destination platform='iOS Simulator,name=iPhone 7,OS=latest'
- - bundle exec pod lib lint --quick
+- xcodebuild test -project Example/RFIBANHelper.xcodeproj -scheme RFIBANHelper build
+  test -destination platform='iOS Simulator,name=iPhone 7,OS=latest'
+- bundle exec pod lib lint --quick
 after_success:
- - bash <(curl -s https://codecov.io/bash)
+- bash <(curl -s https://codecov.io/bash)
 before_install:
- - gem install -v 2.0.1 bundler
- - bundle _2.0.1_ install
- - brew update
- - brew outdated carthage || brew upgrade carthage
+- gem install -v 2.0.1 bundler
+- bundle _2.0.1_ install
+- brew update
+- brew outdated carthage || brew upgrade carthage
 before_deploy:
-  - carthage build --no-skip-current
-  - carthage archive RFIBANHelper
+- carthage build --no-skip-current
+- carthage archive RFIBANHelper
+deploy:
+  provider: releases
+  api_key:
+    secure: jwLd8O8UsQyAdk4fuLqN05/hIQe7+/8qBbK+8Q8+lASf0OS1jpxdT0vTqw0xMNV2Sq1lfdqKu+y1RRJG0UrUHvH4dAke0VIuDajnZY8cjlGf1lbDMmXieJMrSiEE7pCShqI4qsXOQAaGSL6ar5HS/buXj841WLDHT8I7Srs3FQj6X6iYFY+uA4y03A9I++8P+pfdhUKCg2KoZNmbamJ+icrAF/JsWji2wWEAOGvCzkdBsxOr8d5y6IobiOHXA/2/u7qVZQiS49jkU6nMPHnvpqszhjje6Jrky8b0WCGEID8PDYd1cmO6x2B+iPkeMIzVvt+t0GIlxDICQg6wS0dqe64OoYUULiulNsJeA/BXhYK5ILf9CXFf68eNw7mvEXjGvwJ91hfoq5acCA3c1QynBGcIVgVsIjKfGaLKA+TDs0Xh9FB6wOMS4iLjlfPaSvXk82vmRHa6zmPoXTHEQV2J7iandtqacJ1ZXfxdDeF9UMqd2YN0I413CKM4lOIQQijWupF0CkMopltzUrErtt5YT6HKcuhyUAiY1MsM6b3c9E8WKhOaz2X6YFodn3gapkRc5d0MstjUoJ+ENKOHGPsV7sjcPYepmqZsvPvT4xyjGQFi7ZZF5nlw4e09c52kfT8u7+nOyl0Hngs2uCnvZ+e17nUtBC3MTAfLLpyGIY4BwyA=
+  file: RFIBANHelper.framework.zip
+  on:
+    repo: TizianoCoroneo/IBAN-Helper

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Version](https://img.shields.io/cocoapods/v/RFIBAN-Helper.svg?style=flat)](http://cocoapods.org/pods/RFIBAN-Helper)
 [![License](https://img.shields.io/cocoapods/l/RFIBAN-Helper.svg?style=flat)](http://cocoapods.org/pods/RFIBAN-Helper)
 [![Platform](https://img.shields.io/cocoapods/p/RFIBAN-Helper.svg?style=flat)](http://cocoapods.org/pods/RFIBAN-Helper)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 
 A Swift helper class to validate IBAN accounts.
@@ -26,8 +27,10 @@ The dataset used to validate the accounts, is from the [UN/CEFACT - TBG Finance 
 
 ## Installation
 
-RFIBAN-Helper is available through [CocoaPods](http://cocoapods.org). To install
-it, simply add the following line to your Podfile:
+RFIBAN-Helper is available through [CocoaPods](http://cocoapods.org) and [Carthage](https://github.com/Carthage/Carthage). 
+
+### CocoaPods
+To install it, simply add the following line to your Podfile:
 
 For Swift 4 use
 ```ruby
@@ -43,6 +46,16 @@ For Swift 2.3 use
 ```
 pod 'RFIBAN-Helper', '~> 1.0'
 ```
+
+### Carthage
+
+Add this line in your Cartfile:
+
+```
+github 'readefries/IBAN-Helper' ~> 3.0
+```
+
+This library is available on Carthage starting from version `3.0.4`.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Add this line in your Cartfile:
 github 'readefries/IBAN-Helper' ~> 3.0
 ```
 
-This library is available on Carthage starting from version `3.0.4`.
+This library is available on Carthage starting from version `3.0.3`.
 
 ## Author
 


### PR DESCRIPTION
Hello 👋 

I'd like to use this library in a project that is transitioning from CocoaPods to Carthage, so I added Carthage support to your Travis configuration.
Once you follow the guide [here](https://github.com/Carthage/Carthage#use-travis-ci-to-upload-your-tagged-prebuilt-frameworks), the CI should be able to archive a framework and upload it directly in the GitHub Releases page, where Carthage is able to fetch it.
Specifically, follow point n⁰ 4 to setup your encrypted Github Token for Travis.
I also updated the Xcode version and the iPhone model used by Travis.

Thank you for your work 🙏 