### PR TITLE
fix: fixed a crash when using SPM

### DIFF
--- a/RFIBAN-Helper/Classes/CountryModels.swift
+++ b/RFIBAN-Helper/Classes/CountryModels.swift
@@ -43,7 +43,7 @@ extension Bundle {
         #if SWIFT_PACKAGE
         bundle = .module
         #else
-        bundle = Bundle(for: object_getClass(self)!)
+        bundle = Bundle(for: object_getClass(CountryModels.self)!)
         #endif
 
         return bundle

--- a/RFIBAN-Helper/Classes/CountryModels.swift
+++ b/RFIBAN-Helper/Classes/CountryModels.swift
@@ -13,7 +13,7 @@ public class CountryModels {
     
     public func loadModels() {
         do {
-            guard let jsonPath = Bundle(for: object_getClass(self)!).path(forResource: "IBANStructure", ofType: "json")
+            guard let jsonPath = Bundle.assets.path(forResource: "IBANStructure", ofType: "json")
                   else {
                 preconditionFailure("Unable to read IBANStructure.json")
             }
@@ -34,4 +34,18 @@ public class CountryModels {
     public func model(_ countryCode: String) -> CountryModel? {
         return models[countryCode]
     }
+}
+
+extension Bundle {
+    static let assets: Bundle = {
+        let bundle: Bundle
+
+        #if SWIFT_PACKAGE
+        bundle = .module
+        #else
+        bundle = Bundle(for: object_getClass(self)!)
+        #endif
+
+        return bundle
+    }()
 }


### PR DESCRIPTION
When using SPM you HAVE TO use `Bundle.module` otherwise you get a crash because the system cannot find the resource files.

I fixed this issue in [my PR to support SPM](https://github.com/readefries/IBAN-Helper/pull/17/files), but it was lost in the last refactor.

The crash
<img width="789" alt="Screen Shot 2021-03-03 at 11 51 27" src="https://user-images.githubusercontent.com/15340382/109796098-09c69280-7c18-11eb-89de-b9ee0f627697.png">

The refactor
https://github.com/readefries/IBAN-Helper/commit/97ab5bcfdb19509c5566de11aa01d9ecd8ed4cdb
