### PR TITLE
Fix crash when validating IBANs with long sequences of zeros such as BR0200000000010670000117668C1

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,8 +1,6 @@
 use_frameworks!
 
 
-target 'RFIBAN-Helper_Tests', :exclusive => true do
+target 'RFIBANHelper_Tests' do
   pod 'RFIBAN-Helper', :path => '../'
-
-  
 end

--- a/Example/RFIBANHelper.xcodeproj/project.pbxproj
+++ b/Example/RFIBANHelper.xcodeproj/project.pbxproj
@@ -10,10 +10,12 @@
 		1725A675257F949600BBEEB9 /* CountryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1725A674257F949600BBEEB9 /* CountryModel.swift */; };
 		1725A679257FAB8300BBEEB9 /* CountryModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1725A678257FAB8300BBEEB9 /* CountryModels.swift */; };
 		1725A67D2580BE6600BBEEB9 /* IBANStructure.json in Resources */ = {isa = PBXBuildFile; fileRef = 1725A67C2580BE6600BBEEB9 /* IBANStructure.json */; };
+		3B5BE3DC27FB30CA00EFE797 /* CountryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5BE3DB27FB30CA00EFE797 /* CountryTests.swift */; };
 		B142B7A51CD28CED006E3F2A /* RFIBANHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = B142B7A41CD28CED006E3F2A /* RFIBANHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B142B7AC1CD28D08006E3F2A /* RFIBANHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16B6C2F1CC77F3C00D4BDD7 /* RFIBANHelper.swift */; };
 		B142B7AD1CD28D08006E3F2A /* ISO7064.swift in Sources */ = {isa = PBXBuildFile; fileRef = B142B79B1CCE2207006E3F2A /* ISO7064.swift */; };
 		B142B7AF1CD28D57006E3F2A /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
+		B3FE22BD22BEFA0398D449AA /* Pods_RFIBANHelper_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2C41AF5B2DADF605573C043 /* Pods_RFIBANHelper_Tests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -30,6 +32,7 @@
 		1725A674257F949600BBEEB9 /* CountryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CountryModel.swift; path = "../RFIBAN-Helper/Classes/CountryModel.swift"; sourceTree = "<group>"; };
 		1725A678257FAB8300BBEEB9 /* CountryModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CountryModels.swift; path = "../RFIBAN-Helper/Classes/CountryModels.swift"; sourceTree = "<group>"; };
 		1725A67C2580BE6600BBEEB9 /* IBANStructure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = IBANStructure.json; path = "../RFIBAN-Helper/Assets/IBANStructure.json"; sourceTree = "<group>"; };
+		3B5BE3DB27FB30CA00EFE797 /* CountryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryTests.swift; sourceTree = "<group>"; };
 		3BDB832E132342916FBA400B /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		607FACE51AFB9204008FA782 /* RFIBANHelper_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RFIBANHelper_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -42,6 +45,9 @@
 		B142B7A61CD28CED006E3F2A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B16B6C2F1CC77F3C00D4BDD7 /* RFIBANHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RFIBANHelper.swift; path = "../RFIBAN-Helper/Classes/RFIBANHelper.swift"; sourceTree = "<group>"; };
 		B192EE541E26101000032A89 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		BD54AEB6174E446FF6D2C186 /* Pods-RFIBANHelper_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RFIBANHelper_Tests.release.xcconfig"; path = "Target Support Files/Pods-RFIBANHelper_Tests/Pods-RFIBANHelper_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		C2C41AF5B2DADF605573C043 /* Pods_RFIBANHelper_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RFIBANHelper_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EB7288780AA1849724B6C1B3 /* Pods-RFIBANHelper_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RFIBANHelper_Tests.debug.xcconfig"; path = "Target Support Files/Pods-RFIBANHelper_Tests/Pods-RFIBANHelper_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		EBBBF1F8E37D1ACCE5A67C55 /* RFIBAN-Helper.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = "RFIBAN-Helper.podspec"; path = "../RFIBAN-Helper.podspec"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -50,6 +56,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B3FE22BD22BEFA0398D449AA /* Pods_RFIBANHelper_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -72,6 +79,8 @@
 				607FACE81AFB9204008FA782 /* Tests */,
 				B142B7A31CD28CED006E3F2A /* RFIBANHelper */,
 				607FACD11AFB9204008FA782 /* Products */,
+				A3850D9F701C883FFA584AD4 /* Pods */,
+				6D3335CB0945B460FE98F214 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -88,6 +97,7 @@
 			isa = PBXGroup;
 			children = (
 				607FACEB1AFB9204008FA782 /* Tests.swift */,
+				3B5BE3DB27FB30CA00EFE797 /* CountryTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 			);
 			path = Tests;
@@ -110,6 +120,23 @@
 				3BDB832E132342916FBA400B /* LICENSE */,
 			);
 			name = "Podspec Metadata";
+			sourceTree = "<group>";
+		};
+		6D3335CB0945B460FE98F214 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				C2C41AF5B2DADF605573C043 /* Pods_RFIBANHelper_Tests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		A3850D9F701C883FFA584AD4 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				EB7288780AA1849724B6C1B3 /* Pods-RFIBANHelper_Tests.debug.xcconfig */,
+				BD54AEB6174E446FF6D2C186 /* Pods-RFIBANHelper_Tests.release.xcconfig */,
+			);
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		B142B7A31CD28CED006E3F2A /* RFIBANHelper */ = {
@@ -151,9 +178,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACF21AFB9204008FA782 /* Build configuration list for PBXNativeTarget "RFIBANHelper_Tests" */;
 			buildPhases = (
+				C5067E4AC0264644ADEFC8C7 /* [CP] Check Pods Manifest.lock */,
 				607FACE11AFB9204008FA782 /* Sources */,
 				607FACE21AFB9204008FA782 /* Frameworks */,
 				607FACE31AFB9204008FA782 /* Resources */,
+				8F23EEC3488E77EACD60CA1B /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -243,11 +272,55 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		8F23EEC3488E77EACD60CA1B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RFIBANHelper_Tests/Pods-RFIBANHelper_Tests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/RFIBAN-Helper/RFIBAN_Helper.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RFIBAN_Helper.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RFIBANHelper_Tests/Pods-RFIBANHelper_Tests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C5067E4AC0264644ADEFC8C7 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RFIBANHelper_Tests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		607FACE11AFB9204008FA782 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3B5BE3DC27FB30CA00EFE797 /* CountryTests.swift in Sources */,
 				B142B7AF1CD28D57006E3F2A /* Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -382,6 +455,7 @@
 		};
 		607FACF31AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EB7288780AA1849724B6C1B3 /* Pods-RFIBANHelper_Tests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = V8T47KEK9L;
@@ -405,6 +479,7 @@
 		};
 		607FACF41AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BD54AEB6174E446FF6D2C186 /* Pods-RFIBANHelper_Tests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = V8T47KEK9L;

--- a/Example/Tests/CountryTests.swift
+++ b/Example/Tests/CountryTests.swift
@@ -1,0 +1,615 @@
+//
+//  CountryTests.swift
+//  RFIBANHelper_Tests
+//
+//  Created by Alin Radut on 4/4/22.
+//  Copyright © 2022 CocoaPods. All rights reserved.
+//
+
+import XCTest
+
+@testable import RFIBANHelper
+
+class CountryTests: XCTestCase {
+    func testValidityOfALIban() {
+        let sut = "AL06202111090000000005012075"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfADIban() {
+        let sut = "AD1000060004451247870930"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfAZIban() {
+        let sut = "AZ04UBAZ04003214540060AZN001"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfBHIban() {
+        let sut = "BH02CITI00001077181611"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfBEIban() {
+        let sut = "BE45096920886089"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfBAIban() {
+        let sut = "BA391011606058553319"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfBRIban() {
+        let sut = "BR0200000000010670000117668C1"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfVGIban() {
+        let sut = "VG48NOSC0000000005002993"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfBGIban() {
+        let sut = "BG02RZBB91551002755190"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfCRIban() {
+        let sut = "CR79015202220005614288"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfDKIban() {
+        let sut = "DK0220005036459478"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfDEIban() {
+        let sut = "DE02100500000024290661"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfDOIban() {
+        let sut = "DO22BCBH00000000011003290022"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+//    func testValidityOfSVIban() {
+//        let sut = "SV43ACAT00000000000000123123"
+//
+//        let result = RFIBANHelper.isValidIBAN(sut)
+//
+//        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+//    }
+
+    func testValidityOfEEIban() {
+        let sut = "EE021700017000459042"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfFOIban() {
+        let sut = "FO1291810001441878"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfFIIban() {
+        let sut = "FI0210403500314392"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfFRIban() {
+        let sut = "FR7630006000011234567890189"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfGEIban() {
+        let sut = "GE02TB7523045063700002"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfGIIban() {
+        let sut = "GI04BARC020452163087000"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfGRIban() {
+        let sut = "GR0201102160000021661309175"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfGLIban() {
+        let sut = "GL2664710001504964"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfGBIban() {
+        let sut = "GB11CITI18500811417983"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfGTIban() {
+        let sut = "GT24CITI01010000000004146026"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+//    func testValidityOfIQIban() {
+//        let sut = "IQ20CBIQ861800101010500"
+//
+//        let result = RFIBANHelper.isValidIBAN(sut)
+//
+//        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+//    }
+
+    func testValidityOfIEIban() {
+        let sut = "IE02BOFI90008413113207"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfISIban() {
+        let sut = "IS040116381002305610911109"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfILIban() {
+        let sut = "IL020108380000002149431"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfITIban() {
+        let sut = "IT43K0310412701000000820420"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfJOIban() {
+        let sut = "JO02SCBL1260000000018525836101"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfKZIban() {
+        let sut = "KZ04319C010005569698"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfQAIban() {
+        let sut = "QA03QNBA000000000060565452001"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfXKIban() {
+        let sut = "XK051301001002074155"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfHRIban() {
+        let sut = "HR0223400093216312031"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfKWIban() {
+        let sut = "KW02NBOK0000000000001000614589"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfLVIban() {
+        let sut = "LV02HABA0551007820897"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfLBIban() {
+        let sut = "LB02001400000302300023018319"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfLIIban() {
+        let sut = "LI0308800000022875748"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfLTIban() {
+        let sut = "LT027300010134441147"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfLUIban() {
+        let sut = "LU020019175546294000"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfMTIban() {
+        let sut = "MT02VALL22013000000040013752732"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfMRIban() {
+        let sut = "MR1300012000010000009880016"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfMUIban() {
+        let sut = "MU03MCBL0901000001879025000USD"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfMKIban() {
+        let sut = "MK07200000625758632"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfMDIban() {
+        let sut = "MD14MO2224ASV41884097100"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfMCIban() {
+        let sut = "MC2412739000710075018000P14"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfMEIban() {
+        let sut = "ME25505120000000466170"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfNLIban() {
+        let sut = "NL02ABNA0457180536"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfNOIban() {
+        let sut = "NO0239916835985"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfATIban() {
+        let sut = "AT021100000622888600"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfPKIban() {
+        let sut = "PK02SCBL0000001925518401"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfPSIban() {
+        let sut = "PS06ARAB000000009040781605610"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfPLIban() {
+        let sut = "PL02103000190109780401676562"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfPTIban() {
+        let sut = "PT50003600409911001102673"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfROIban() {
+        let sut = "RO02BRDE445SV75163474450"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfLCIban() {
+        let sut = "LC55HEMM000100010012001200023015"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfSMIban() {
+        let sut = "SM07U0854009803000030174419"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfSTIban() {
+        let sut = "ST23000200000289355710148"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfSAIban() {
+        let sut = "SA0220000002480647579940"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfSEIban() {
+        let sut = "SE0230000000030301099952"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfCHIban() {
+        let sut = "CH020020720710117540C"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfRSIban() {
+        let sut = "RS35105008054113238018"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfSCIban() {
+        let sut = "SC74NOVH00000021002035257028SCR"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfSKIban() {
+        let sut = "SK0202000000003679748552"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfSIIban() {
+        let sut = "SI56011006000005649"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfESIban() {
+        let sut = "ES1321000555370200853027"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfTLIban() {
+        let sut = "TL380030000000025923744"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfTRIban() {
+        let sut = "TR020001000201529153355002"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfCZIban() {
+        let sut = "CZ0201000000199216760237"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfTNIban() {
+        let sut = "TN5901026067111999766058"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfUAIban() {
+        let sut = "UA123052990004149497803982794"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfHUIban() {
+        let sut = "HU02116000060000000064247067"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+    func testValidityOfAEIban() {
+        let sut = "AE020090004001079346500"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+//    func testValidityOfBYIban() {
+//        let sut = "BY86AKBB10100000002966000000"
+//
+//        let result = RFIBANHelper.isValidIBAN(sut)
+//
+//        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+//    }
+
+    func testValidityOfCYIban() {
+        let sut = "CY02002001950000357009822416"
+
+        let result = RFIBANHelper.isValidIBAN(sut)
+
+        XCTAssert(result == .validIban, "\(sut) should be a valid IBAN, yet the result is \(result)")
+    }
+
+
+}

--- a/RFIBAN-Helper/Classes/ISO7064.swift
+++ b/RFIBAN-Helper/Classes/ISO7064.swift
@@ -17,7 +17,7 @@ public class ISO7064: NSObject {
 
       let chunk = Int(remainingInput[remainingInput.startIndex..<remainingInput.index(remainingInput.startIndex, offsetBy: chunkSize)])
 
-      if chunk! < 97 || remainingInput.count < 3 {
+      if remainingInput.count < 3 {
         break
       }
 


### PR DESCRIPTION
This PR also adds tests for all countries listed under https://www.iban.de/iban-laenderliste.html and fixes the Podfile which references the incorrect tests target.